### PR TITLE
Fix for AAPT2 Compile error in Android Studio 3.0 Canary

### DIFF
--- a/pluginClientSdkLib/src/main/res/values-hdpi/integers.xml
+++ b/pluginClientSdkLib/src/main/res/values-hdpi/integers.xml
@@ -14,8 +14,6 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <integer name="com_twofortyfouram_locale_sdk_client_maximum_blurb_length" tools:ignore="UnusedResources">
-        60
-    </integer>
+    <integer name="com_twofortyfouram_locale_sdk_client_maximum_blurb_length" tools:ignore="UnusedResources">60</integer>
 
 </resources>

--- a/pluginClientSdkLib/src/main/res/values-ldpi/integers.xml
+++ b/pluginClientSdkLib/src/main/res/values-ldpi/integers.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <integer name="com_twofortyfouram_locale_sdk_client_maximum_blurb_length" tools:ignore="UnusedResources">45
-    </integer>
+    <integer name="com_twofortyfouram_locale_sdk_client_maximum_blurb_length" tools:ignore="UnusedResources">45</integer>
 
 </resources>

--- a/pluginClientSdkLib/src/main/res/values-mdpi/integers.xml
+++ b/pluginClientSdkLib/src/main/res/values-mdpi/integers.xml
@@ -15,7 +15,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- The maximum blurb length in characters.  This value is based on Latin characters. -->
-    <integer name="com_twofortyfouram_locale_sdk_client_maximum_blurb_length" tools:ignore="UnusedResources">50
-    </integer>
+    <integer name="com_twofortyfouram_locale_sdk_client_maximum_blurb_length" tools:ignore="UnusedResources">50</integer>
 
 </resources>


### PR DESCRIPTION
I've submitted a bug report to Google about this, but since the fix is simple and stupid, I thought I'd submit the change to you. Apparently the AAPT2 compiler in the Gradle plugin that works with Android Studio 3.0 Canary 2 is picky about formatting of the integer resource. Removing whitespace fixes the issue, so I've done that here.